### PR TITLE
Pinned rollbar/rollbar to 1.6.* to be compatible with their Defaults class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "require": {
         "php": ">=5.6",
-        "rollbar/rollbar": "^1",
+        "rollbar/rollbar": "~1.6.0",
         "symfony/dependency-injection": "^3.4 | ^4.0",
         "symfony/config": "^3.4 | ^4.0",
         "symfony/http-kernel": "^3.4 | ^4.0",


### PR DESCRIPTION
Compatibility with `rollbar/rollbar` was broken per **1.7.0** by the following change:
https://github.com/rollbar/rollbar-php/commit/034a5c3467bb92f2194bbe63819f74065e3dc443#diff-af83e36df325a404cd1ea180a0d083ac

Previously, when you defined a config parameter like `access_token` it would invoke `Defaults::fromSnakeCase` which in turn would explicity raise an `\Exception` when the corresponding method (`accessToken`) does not exist on the Defaults class. This exception was then caught in the `Configuration` class of this bundle, which would interpreted this as the default value being `null`.

Per **1.7.0** the exception mentioned above is no langer raised, thus the catch block in the `Configuration` class will no longer be reached. Instead the error will escalate during SF cache warmups like this:
```php
[RuntimeException]                                                                                                                                                                                                               
An error occurred when executing the "'cache:clear --no-warmup'" command:                                                                                                                                                        
                                                                                                                                                                                                                                   
PHP Fatal error:  Uncaught Symfony\Component\Debug\Exception\UndefinedMethodException: Attempted to call an undefined method named "accessToken" of class "Rollbar\Defaults". in /project/vendor/rollbar/
rollbar/src/Defaults.php:79

Stack trace:
#0 /project/vendor/rollbar/rollbar-php-symfony3-bundle/DependencyInjection/Configuration.php(42): Rollbar\Defaults->fromSnakeCase('access_token')
#1 /project/vendor/symfony/config/Definition/Processor.php(50): Rollbar\Symfony\RollbarBundle\DependencyInjection\Configuration->getConfigTreeBuilder()
#2 /project/vendor/symfony/dependency-injection/Extension/Extension.php(96): Symfony\Component\Config\Definition\Processor->processConfiguration(Object(Rollbar\Symfony\RollbarBundle\DependencyInjection\Configuration), Array)
#3 /project/vendor/rollbar/rollbar-php-symfony3-bundle/DependencyInjection/RollbarExtension.php(25): Symfony\Component\DependencyInjection\Extension\Extension->process in /project/vendor/rollbar/rollbar/src/Defaults.php on line 79

```

In order to circumvent the above problem, I've pinned the `rollbar/rollbar` package to **1.6.***.