### PR TITLE
Change logLevel params on createRollbarHandler

### DIFF
--- a/Factories/RollbarHandlerFactory.php
+++ b/Factories/RollbarHandlerFactory.php
@@ -64,6 +64,6 @@ class RollbarHandlerFactory
      */
     public function createRollbarHandler()
     {
-        return new RollbarHandler(Rollbar::logger(), LogLevel::ERROR);
+        return new RollbarHandler(Rollbar::logger(), LogLevel::INFO);
     }
 }

--- a/Factories/RollbarHandlerFactory.php
+++ b/Factories/RollbarHandlerFactory.php
@@ -30,28 +30,21 @@ class RollbarHandlerFactory
 
         if (!empty($config['person_fn']) && is_callable($config['person_fn'])) {
             $config['person'] = null;
-        } else {
-            
-            if (empty($config['person'])) {
-                
-                $config['person_fn'] = function() use ($container) {
-                    
-                    try {
-                        $token = $container->get('security.token_storage')->getToken();
-                        
-                        if ($token) {
-                            $user = $token->getUser();
-                            $serializer = $container->get('serializer');
-                            $person = \json_decode($serializer->serialize($user, 'json'), true);
-                            return $person;
-                        }
-                    } catch (\Exception $exception) {
-                        // Ignore
+        } elseif (empty($config['person'])) {
+            $config['person_fn'] = function () use ($container) {
+
+                try {
+                    $token = $container->get('security.token_storage')->getToken();
+                    if ($token) {
+                        $user = $token->getUser();
+                        $serializer = $container->get('serializer');
+                        $person = \json_decode($serializer->serialize($user, 'json'), true);
+                        return $person;
                     }
-                };
-                
-            }
-            
+                } catch (\Exception $exception) {
+                    // Ignore
+                }
+            };
         }
 
         Rollbar::init($config, false, false, false);


### PR DESCRIPTION
In project I currently working on there was a need to log info and warning exceptions. There is a createRollbarHandler function in RollbarHandlerFactory class. This LogLevel parameter accepts only Error / Critical values. It would be great if it is possible to put Info value as well. Because info can includes Info/Warning/Error/Critical.

