### PR TITLE
Add listen new config param "minimum_level" error log.

### DIFF
--- a/Factories/RollbarHandlerFactory.php
+++ b/Factories/RollbarHandlerFactory.php
@@ -53,7 +53,7 @@ class RollbarHandlerFactory
             };
         }
 
-        $this->minimumLevel = $config['minimum_level'] ?: LogLevel::ERROR;
+        $this->minimumLevel = isset($config['minimum_level']) ? $config['minimum_level'] : LogLevel::ERROR;
 
         Rollbar::init($config, false, false, false);
     }


### PR DESCRIPTION
Hello everybody.

Problem:
In the project, I am currently working on it. There is a createRollbarHandler function in the RollbarHandlerFactory class. This LogLevel parameter accepts only Error / Critical values. It would be great if it is possible to put it. Because info info includes `Warning / Warning / Error / Critical`.

Solution for the problem:
I created you PR on [rollbar-php](https://github.com/rollbar/rollbar-php/pull/440) when i add new param in config `minimum_level`, and this i use him and determine which error level is required.

Example config:
```
rollbar:
    minimum_level: 'warning'
```