### PR TITLE
Fix usage of deprecated class

### DIFF
--- a/Factories/RollbarHandlerFactory.php
+++ b/Factories/RollbarHandlerFactory.php
@@ -3,6 +3,8 @@
 namespace Rollbar\Symfony\RollbarBundle\Factories;
 
 use Psr\Log\LogLevel;
+use Monolog\Handler\Handler;
+use Monolog\Handler\RollbarHandler as MonologRollbarHandler;
 use Rollbar\Monolog\Handler\RollbarHandler;
 use Rollbar\Rollbar;
 use Rollbar\Symfony\RollbarBundle\DependencyInjection\RollbarExtension;
@@ -52,10 +54,14 @@ class RollbarHandlerFactory
     /**
      * Create RollbarHandler
      *
-     * @return RollbarHandler
+     * @return Handler
      */
-    public function createRollbarHandler(): RollbarHandler
+    public function createRollbarHandler(): Handler
     {
+        if (class_exists(MonologRollbarHandler::class)) {
+            return new MonologRollbarHandler(Rollbar::logger(), LogLevel::ERROR);
+        }
+
         return new RollbarHandler(Rollbar::logger(), LogLevel::ERROR);
     }
 }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -4,10 +4,13 @@ services:
     arguments:
       - '@service_container'
 
-  Rollbar\Monolog\Handler\RollbarHandler:
+  Monolog\Handler\RollbarHandler:
     factory: ['@Rollbar\Symfony\RollbarBundle\Factories\RollbarHandlerFactory', createRollbarHandler]
     tags:
       - { name: monolog.logger, channel: rollbar }
+
+  Rollbar\Monolog\Handler\RollbarHandler:
+    alias: Monolog\Handler\RollbarHandler
 
   Rollbar\Symfony\RollbarBundle\Payload\Generator:
     arguments:


### PR DESCRIPTION
The RollbarHandler is [deprecated](https://github.com/rollbar/rollbar-php/blob/245670b32d8e6072d6b364eda242f245879cdee9/src/Monolog/Handler/RollbarHandler.php#L4). We should use the recommended handler if possible.