### PR TITLE
Support rollbar v1 and v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "require": {
         "php": ">=5.6",
-        "rollbar/rollbar": "^1",
+        "rollbar/rollbar": "^1 | ^2",
         "symfony/dependency-injection": "^3.4 | ^4.0",
         "symfony/config": "^3.4 | ^4.0",
         "symfony/http-kernel": "^3.4 | ^4.0",


### PR DESCRIPTION
Extend the supported versions of [rollbar](https://github.com/rollbar/rollbar-php) so that symfony 4 projects that supports PHP > 7.0 could use latest rollbar version