### PR TITLE
Add ability to use service as a person_fn

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -64,6 +64,12 @@ class Configuration implements ConfigurationInterface
             }
         }
 
+
+        $rollbarConfigNodeChildren
+            ->scalarNode('person_service')
+                ->defaultValue(null)
+            ->end();
+
         return $treeBuilder;
     }
 }

--- a/Factories/RollbarHandlerFactory.php
+++ b/Factories/RollbarHandlerFactory.php
@@ -30,6 +30,17 @@ class RollbarHandlerFactory
 
         if (!empty($config['person_fn']) && is_callable($config['person_fn'])) {
             $config['person'] = null;
+        } elseif (! empty($config['person_service']) && $container->has($config['person_service'])) {
+            $config['person_fn'] = static function () use ($container, $config) {
+                try {
+                    $service = $container->get($config['person_service']);
+
+                    // call service's __invoke method
+                    return $service();
+                } catch (\Exception $exception) {
+                    // Ignore
+                }
+            };
         } elseif (empty($config['person'])) {
             $config['person_fn'] = static function () use ($container) {
                 try {


### PR DESCRIPTION
## Description of the change

This is a new feature to allow person_fn to use a Symfony service. 

## Usage
_This worked for me with Symfony 5.4 I didn't test them on any other Symfony versions_

1. Create a Symfony service with an `__invoke` method that returns the person data array, using DI you can inject any service you want into the `__construct` method
```
<?php

namespace App;

use App\Entity\Person;
use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
use Symfony\Component\Security\Core\User\UserInterface;

class RollbarUserInfo
{
    private ?UserInterface $user = null;

    public function __construct(TokenStorageInterface $tokenStorage)
    {
        $token = $tokenStorage->getToken();

        if (null !== $token) {
            $this->user = $token->getUser();
        }
    }

    /**
     * @return array{
     *      id?: int,
     *      username?: string,
     *      email?: string
     * }
     */
    public function __invoke(): array
    {
        $user = $this->user;

        if ($user instanceof Person) {
            return [
                'id'       => $user->getId(),
                'username' => $user->getName(),
                'email'    => $user->getEmail(),
            ];
        }

        //You can just return an empty array here or implement the default serialize methods here again
        return [];
    }
}

```

2. Define the service as  **public**
```
services:
    App\RollbarUserInfo:
        public: true
```

3. Configure bundle to use the new service
```
rollbar:
    person_service: App\RollbarUserInfo
```

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- Fix #52

## Checklists

### Development

**I could not get any of the tests to run because I could not get the dev dependencies installed.** 

```
  Problem 1
    - matthiasnoback/symfony-dependency-injection-test v1.1.0 requires symfony/dependency-injection ^2.3|^3.0 -> found symfony/dependency-injection[v2.3.0, ..., v2.8.52, v3.0.0, ..., v3.4.47] but it conflicts with your root composer.json require (^5.0).
    - matthiasnoback/symfony-dependency-injection-test v1.2.0 requires symfony/dependency-injection ^2.7 || ^3.3 || ^4.0 -> found symfony/dependency-injection[v2.7.0, ..., v2.8.52, v3.3.0, ..., v3.4.47, v4.0.0, ..., v4.4.34] but it conflicts with your root composer.json require (^5.0).
    - Root composer.json requires matthiasnoback/symfony-dependency-injection-test ^1.1 -> satisfiable by matthiasnoback/symfony-dependency-injection-test[v1.1.0, v1.2.0].
```

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
