### PR TITLE
Fixed #51 To make catch statement broader

### DIFF
--- a/Factories/RollbarHandlerFactory.php
+++ b/Factories/RollbarHandlerFactory.php
@@ -30,7 +30,7 @@ class RollbarHandlerFactory
                         $serializer = $container->get('serializer');
                         return \json_decode($serializer->serialize($user, 'json'), true, 512, JSON_THROW_ON_ERROR);
                     }
-                } catch (\Exception $exception) {
+                } catch (\Throwable $exception) {
                     // Ignore
                 }
             };


### PR DESCRIPTION
## Description of the change

By catching only instances or instances of subclasses of `Exception`. We will not catch any `Error` instances that may be thrown. As a general rule, if the desire is to catch `Exceptions` it is best to catch `Throwable`. This PR simply updates `Exception` to `Throwable`. For more details on the specific issue see #51.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

- Fixed #51

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
