### PR TITLE
fix: default fn-username behaviour

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -3,6 +3,8 @@ services:
   Rollbar\Symfony\RollbarBundle\Factories\RollbarHandlerFactory:
     arguments:
       - '@service_container'
+      - '@serializer'
+      - '@?security.helper'
 
   Rollbar\Monolog\Handler\RollbarHandler:
     factory: ['@Rollbar\Symfony\RollbarBundle\Factories\RollbarHandlerFactory', createRollbarHandler]

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
         "phpunit/phpunit": "^9.6|^10.1",
         "symfony/framework-bundle": "^5.4|^6.2",
         "squizlabs/php_codesniffer": "^3.7",
-        "matthiasnoback/symfony-dependency-injection-test": "^4.3"
+        "matthiasnoback/symfony-dependency-injection-test": "^4.3",
+        "symfony/security-bundle": "^5.4|^6.2"
     },
     "scripts": {
         "test": [


### PR DESCRIPTION
## Description of the change

The service are all private by default in Symfony 6.

This PR needs a closer look.
It will only work if the "symfony/security-bundle" is installed. But i let it optional, as user can provide there own callback function instead of the default.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

- Fix [#609](https://github.com/rollbar/rollbar-php-symfony-bundle/issues/91)