### PR TITLE
symfony7 compatibility

### DIFF
--- a/Tests/Payload/GeneratorTest.php
+++ b/Tests/Payload/GeneratorTest.php
@@ -82,7 +82,7 @@ class GeneratorTest extends KernelTestCase
      */
     public function testGetRequestInfo(): void
     {
-        $container = self::getContainer();
+        $container = static::$kernel->getContainer();
         $generator = $this->getGenerator();
 
         $request = $container->get('request_stack')->getCurrentRequest();
@@ -185,15 +185,11 @@ class GeneratorTest extends KernelTestCase
         $this->assertEquals($serverInfo, $payload['server']);
     }
 
-    protected static function getContainer(): ContainerInterface
-    {
-        return static::$container ?? static::$kernel->getContainer();
-    }
-
     private function getGenerator(): Generator
     {
+        $container = static::$kernel->getContainer();
         /** @var $generator Generator */
-        $generator = self::getContainer()->get('test.' . Generator::class);
+        $generator = $container->get('test.' . Generator::class);
         return $generator;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -28,16 +28,16 @@
     "require": {
         "php": ">=8.0.2",
         "rollbar/rollbar": "^3.1|^4.0",
-        "symfony/dependency-injection": "^5.4|^6.2",
-        "symfony/config": "^5.4|^6.2",
-        "symfony/http-kernel": "^5.4|^6.2",
+        "symfony/dependency-injection": "^5.4|^6.2|^7.0",
+        "symfony/config": "^5.4|^6.2|^7.0",
+        "symfony/http-kernel": "^5.4|^6.2|^7.0",
         "symfony/monolog-bundle": "^3.8",
-        "symfony/serializer": "^5.4|^6.2",
+        "symfony/serializer": "^5.4|^6.2|^7.0",
         "ext-json": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6|^10.1",
-        "symfony/framework-bundle": "^5.4|^6.2",
+        "symfony/framework-bundle": "^5.4|^6.2|^7.0",
         "squizlabs/php_codesniffer": "^3.7",
         "matthiasnoback/symfony-dependency-injection-test": "^4.3"
     },


### PR DESCRIPTION
Allows the usage of the bundle with Symfony 7.

I have added ^7.0 version to the used symfony packages.
I had to remove the getContainer() function in GeneratorTest due to changed return type in KernelTestCase in Symfony 7. This way it will be compatible with Symfony 7 and prior versions.